### PR TITLE
Bump minimum CMake version to fix install error.

### DIFF
--- a/esim_py/CMakeLists.txt
+++ b/esim_py/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.3)
 project(esim_py)
 
 find_package(pybind11 REQUIRED)


### PR DESCRIPTION
When I tried to install without the python=3.7 version constraint [*], I got a CMake error. With the help of https://stackoverflow.com/questions/62930429/c-avro-cmake-failed I managed to fix it by bumping the CMake version.

I don't know if this causes any regression, but since 3.3 was released in 2015, I think it should be fine.

[*] with the 3.7 constraint, trying to install jupyterlab caused version conflicts. With this fix, everything seems to work.