### PR TITLE
Added the 'conda-forge' channel as well to get some conda packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ git clone git@github.com:uzh-rpg/rpg_vid2e.git --recursive
 
 ```bash
 conda config --add channel pytorch
+conda config --append channels conda-forge
 conda create --name vid2e --file requirements.txt
 conda install -y -c conda-forge pybind11 matplotlib
 ```


### PR DESCRIPTION
The following packages were not available in either of the bellow mentioned channels previously. Hence `conda-forge` channel was needed to these packages to be downloaded

```
PackagesNotFoundError: The following packages are not available from current channels:

  - libgfortran==3.0.0=1
  - freeglut==3.2.1=h58526e2_0
  - pcre==8.44=he1b5a44_0
  - boost==1.70.0=py37h9de70de_1
  - xorg-libxau==1.0.9=h14c3975_0
  - libuuid==2.32.1=h14c3975_1000
  - xorg-fixesproto==5.0=h14c3975_1002
  - python_abi==3.7=1_cp37m
  - xorg-libx11==1.6.12=h516909a_0
  - scikit-video==1.1.11=pyh24bf2e0_0
  - xorg-libxfixes==5.0.3=h516909a_1004
  - xorg-xproto==7.0.31=h14c3975_1007
  - xorg-inputproto==2.3.2=h14c3975_1002
  - pixman==0.34.0=h14c3975_1003
  - libgfortran-ng==7.5.0=h14aa051_19
  - libgfortran4==7.5.0=h14aa051_19
  - xorg-libxi==1.7.10=h516909a_0
  - tqdm==4.60.0=pyhd8ed1ab_0
  - boost-cpp==1.70.0=ha2d47e9_1
  - xorg-renderproto==0.11.1=h14c3975_1002
  - libxcb==1.13=h14c3975_1002
  - fontconfig==2.13.1=he4413a7_1000
  - pthread-stubs==0.4=h36c2ea0_1001
  - icu==58.2=hf484d3e_1000
  - xorg-libsm==1.2.3=h84519dc_1000
  - graphite2==1.3.13=h58526e2_1001
  - xorg-libxext==1.3.4=h516909a_0
  - hdf5==1.10.2=hc401514_3
  - xorg-libxrender==0.9.10=h516909a_1002
  - xorg-libice==1.0.10=h516909a_0
  - xorg-libxdmcp==1.1.3=h516909a_0
  - libglu==9.0.0=he1b5a44_1001
  - gettext==0.19.8.1=h5e8e0c9_1
  - eigen==3.3.8=h0efe328_0
  - xorg-kbproto==1.0.7=h14c3975_1002
  - xorg-xextproto==7.3.0=h14c3975_1002
  - libxml2==2.9.9=h13577e0_2

Current channels:

  - https://conda.anaconda.org/pytorch/linux-64
  - https://conda.anaconda.org/pytorch/noarch
  - https://repo.anaconda.com/pkgs/main/linux-64
  - https://repo.anaconda.com/pkgs/main/noarch
  - https://repo.anaconda.com/pkgs/r/linux-64
  - https://repo.anaconda.com/pkgs/r/noarch
```
